### PR TITLE
Add URI-based file data support

### DIFF
--- a/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -158,7 +158,7 @@ class FunctionCallingViewModel: ObservableObject {
       case let .functionCall(functionCall):
         messages.insert(functionCall.chatMessage(), at: messages.count - 1)
         functionCalls.append(functionCall)
-      case .data, .functionResponse:
+      case .data, .fileData, .functionResponse:
         fatalError("Unsupported response content.")
       }
     }

--- a/Sources/GoogleAI/Chat.swift
+++ b/Sources/GoogleAI/Chat.swift
@@ -153,7 +153,7 @@ public class Chat {
         case let .text(str):
           combinedText += str
 
-        case .data, .functionCall, .functionResponse:
+        case .data, .fileData, .functionCall, .functionResponse:
           // Don't combine it, just add to the content. If there's any text pending, add that as
           // a part.
           if !combinedText.isEmpty {

--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -45,13 +45,19 @@ public struct ModelContent: Codable, Equatable {
 
     /// Data with a specified media type.
     ///
-    /// > Note: Supported media types depends on the model.
+    /// > Note: Supported media types depends on the model; see
+    /// > [supported file
+    /// > formats](https://ai.google.dev/tutorials/prompting_with_media#supported_file_formats)
+    /// > for details.
     case data(mimetype: String, Data)
 
     /// URI-based data with a specified media type.
     ///
-    /// > Note: Supported media types depends on the model.
-    case fileData(mimetype: String, URL)
+    /// > Note: Supported media types depends on the model; see
+    /// > [supported file
+    /// > formats](https://ai.google.dev/tutorials/prompting_with_media#supported_file_formats)
+    /// > for details.
+    case fileData(mimetype: String, uri: String)
 
     /// A predicted function call returned from the model.
     case functionCall(FunctionCall)

--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -25,6 +25,7 @@ public struct ModelContent: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
       case text
       case inlineData
+      case fileData
       case functionCall
       case functionResponse
     }
@@ -34,11 +35,23 @@ public struct ModelContent: Codable, Equatable {
       case bytes = "data"
     }
 
+    enum FileDataKeys: String, CodingKey {
+      case mimeType = "mime_type"
+      case url = "file_uri"
+    }
+
     /// Text value.
     case text(String)
 
-    /// Data with a specified media type. Not all media types may be supported by the AI model.
+    /// Data with a specified media type.
+    ///
+    /// > Note: Supported media types depends on the model.
     case data(mimetype: String, Data)
+
+    /// URI-based data with a specified media type.
+    ///
+    /// > Note: Supported media types depends on the model.
+    case fileData(mimetype: String, URL)
 
     /// A predicted function call returned from the model.
     case functionCall(FunctionCall)
@@ -72,6 +85,13 @@ public struct ModelContent: Codable, Equatable {
         )
         try inlineDataContainer.encode(mimetype, forKey: .mimeType)
         try inlineDataContainer.encode(bytes, forKey: .bytes)
+      case let .fileData(mimetype: mimetype, url):
+        var fileDataContainer = container.nestedContainer(
+          keyedBy: FileDataKeys.self,
+          forKey: .fileData
+        )
+        try fileDataContainer.encode(mimetype, forKey: .mimeType)
+        try fileDataContainer.encode(url, forKey: .url)
       case let .functionCall(functionCall):
         try container.encode(functionCall, forKey: .functionCall)
       case let .functionResponse(functionResponse):


### PR DESCRIPTION
Added support for URI-based file data (in addition to existing support for data as inline bytes). Files may be uploaded using the [`media.upload`](https://ai.google.dev/api/rest/v1beta/media/upload) REST API.