### PR TITLE
Update default API version from `v1` to `v1beta`

### DIFF
--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -38,8 +38,8 @@ public struct RequestOptions {
   /// - Parameters:
   ///   - timeout The request’s timeout interval in seconds; if not specified uses the default value
   ///   for a `URLRequest`.
-  ///   - apiVersion The API version to use in requests to the backend; defaults to "v1".
-  public init(timeout: TimeInterval? = nil, apiVersion: String = "v1") {
+  ///   - apiVersion The API version to use in requests to the backend; defaults to "v1beta".
+  public init(timeout: TimeInterval? = nil, apiVersion: String = "v1beta") {
     self.timeout = timeout
     self.apiVersion = apiVersion
   }


### PR DESCRIPTION
Updated the default API version from `v1` to `v1beta`. This allows several SDK features, such as function calling and system instructions, and new models, such as `gemini-1.5-pro-latest` to be used without setting `apiVersion` in `RequestOptions` when instantiating a model.