### PR TITLE
Remove extraneous `apiVersion: "v1beta"` in function calling sample

### DIFF
--- a/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -61,8 +61,7 @@ class FunctionCallingViewModel: ObservableObject {
           ],
           requiredParameters: ["currency_from", "currency_to"]
         ),
-      ])],
-      requestOptions: RequestOptions(apiVersion: "v1beta")
+      ])]
     )
     chat = model.startChat()
   }


### PR DESCRIPTION
Specifying `RequestOptions(apiVersion: "v1beta")` is no longer necessary in the Function Calling sample since it is the default as of #137.