### PR TITLE
Make `Citation.license` optional

### DIFF
--- a/Sources/GoogleAI/GenerateContentResponse.swift
+++ b/Sources/GoogleAI/GenerateContentResponse.swift
@@ -184,8 +184,8 @@ public struct Citation {
   /// A link to the cited source.
   public let uri: String
 
-  /// The license the cited source work is distributed under.
-  public let license: String
+  /// The license the cited source work is distributed under, if specified.
+  public let license: String?
 }
 
 /// A value enumerating possible reasons for a model to terminate a content generation request.
@@ -314,6 +314,11 @@ extension Citation: Decodable {
     startIndex = try container.decodeIfPresent(Int.self, forKey: .startIndex) ?? 0
     endIndex = try container.decode(Int.self, forKey: .endIndex)
     uri = try container.decode(String.self, forKey: .uri)
-    license = try container.decodeIfPresent(String.self, forKey: .license) ?? ""
+    if let license = try container.decodeIfPresent(String.self, forKey: .license),
+       !license.isEmpty {
+      self.license = license
+    } else {
+      license = nil
+    }
   }
 }

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -109,17 +109,17 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(citationSource1.uri, "https://www.example.com/some-citation-1")
     XCTAssertEqual(citationSource1.startIndex, 0)
     XCTAssertEqual(citationSource1.endIndex, 128)
-    XCTAssertEqual(citationSource1.license, "")
+    XCTAssertNil(citationSource1.license)
     let citationSource2 = try XCTUnwrap(citationMetadata.citationSources[1])
     XCTAssertEqual(citationSource2.uri, "https://www.example.com/some-citation-2")
     XCTAssertEqual(citationSource2.startIndex, 130)
     XCTAssertEqual(citationSource2.endIndex, 265)
-    XCTAssertEqual(citationSource2.license, "")
+    XCTAssertNil(citationSource2.license)
     let citationSource3 = try XCTUnwrap(citationMetadata.citationSources[2])
     XCTAssertEqual(citationSource3.uri, "https://www.example.com/some-citation-3")
     XCTAssertEqual(citationSource3.startIndex, 272)
     XCTAssertEqual(citationSource3.endIndex, 431)
-    XCTAssertEqual(citationSource3.license, "")
+    XCTAssertNil(citationSource3.license)
     let citationSource4 = try XCTUnwrap(citationMetadata.citationSources[3])
     XCTAssertEqual(citationSource4.uri, "https://www.example.com/some-citation-4")
     XCTAssertEqual(citationSource4.startIndex, 444)
@@ -740,15 +740,15 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(citations.count, 8)
     XCTAssertTrue(citations
       .contains(where: {
-        $0.startIndex == 0 && $0.endIndex == 128 && !$0.uri.isEmpty && $0.license.isEmpty
+        $0.startIndex == 0 && $0.endIndex == 128 && !$0.uri.isEmpty && $0.license == nil
       }))
     XCTAssertTrue(citations
       .contains(where: {
-        $0.startIndex == 130 && $0.endIndex == 265 && !$0.uri.isEmpty && $0.license.isEmpty
+        $0.startIndex == 130 && $0.endIndex == 265 && !$0.uri.isEmpty && $0.license == nil
       }))
     XCTAssertTrue(citations
       .contains(where: {
-        $0.startIndex == 272 && $0.endIndex == 431 && !$0.uri.isEmpty && $0.license.isEmpty
+        $0.startIndex == 272 && $0.endIndex == 431 && !$0.uri.isEmpty && $0.license == nil
       }))
     XCTAssertTrue(citations
       .contains(where: {


### PR DESCRIPTION
As a follow-up to #135, made `Citation.license` a `String?`. The `license` is now `nil` if not provided by the backend (future-proofing) or if the provided license is an empty string (current response behaviour). This now matches the [`Citation.license`](https://github.com/firebase/firebase-ios-sdk/blob/3783c8a1c3b5058cca47d81b20a903299b1f861f/FirebaseVertexAI/Sources/GenerateContentResponse.swift#L192) public API in the Vertex AI preview.