### PR TITLE
Use Python 3.10 in `check` job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: '3.10'
 
     - name: Cache Mint packages
       uses: actions/cache@v3


### PR DESCRIPTION
Updated to Python 3.10 since Python 3.6 [isn't available](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json) on `arm64`.
- This should fix https://github.com/google-gemini/generative-ai-swift/actions/runs/8819288849/job/24210118892?pr=145#step:3:12
- Aligns with https://github.com/firebase/firebase-ios-sdk/pull/12847
