### PR TITLE
Update issue template link wording

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        **Note:** If this is a support question (e.g. _How do I do XYZ?_), please visit the [Discourse forum](https://discuss.ai.google.dev/). This is a great place to interact with developers, and to learn, share, and support each other.
+        **Note:** If this is a support question (e.g. _How do I do XYZ?_), please visit the [Build with Google AI Forum](https://discuss.ai.google.dev/). This is a great place to interact with developers, and to learn, share, and support each other.
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: >
-        **Note:** If this is a support question (e.g. _How do I do XYZ?_), please visit the [Discourse forum](https://discuss.ai.google.dev/). This is a great place to interact with developers, and to learn, share, and support each other.
+        **Note:** If this is a support question (e.g. _How do I do XYZ?_), please visit the [Build with Google AI Forum](https://discuss.ai.google.dev/). This is a great place to interact with developers, and to learn, share, and support each other.
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
nit: Updated the link in #148 to say "Build with Google AI Forum" to avoid any confusion between Discord/Discourse or Discourse/discuss (from the URL).