### PR TITLE
Add default `nil` value for `requiredParameters` in `FunctionDeclaration`

### DIFF
--- a/Sources/GoogleAI/FunctionCalling.swift
+++ b/Sources/GoogleAI/FunctionCalling.swift
@@ -142,7 +142,7 @@ public struct FunctionDeclaration {
   ///   the values are ``Schema`` objects describing them.
   ///   - requiredParameters: A list of required parameters by name.
   public init(name: String, description: String, parameters: [String: Schema]?,
-              requiredParameters: [String]?) {
+              requiredParameters: [String]? = nil) {
     self.name = name
     self.description = description
     self.parameters = Schema(


### PR DESCRIPTION
Added a default value of `nil` for `requiredParameters` in `FunctionDeclaration`.