### PR TITLE
Make system instruction accept variadic `String...`

### DIFF
--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -64,7 +64,7 @@ public final class GenerativeModel {
                           safetySettings: [SafetySetting]? = nil,
                           tools: [Tool]? = nil,
                           toolConfig: ToolConfig? = nil,
-                          systemInstruction: String,
+                          systemInstruction: String...,
                           requestOptions: RequestOptions = RequestOptions()) {
     self.init(
       name: name,
@@ -73,7 +73,10 @@ public final class GenerativeModel {
       safetySettings: safetySettings,
       tools: tools,
       toolConfig: toolConfig,
-      systemInstruction: ModelContent(role: "system", parts: systemInstruction),
+      systemInstruction: ModelContent(
+        role: "system",
+        parts: systemInstruction.map { ModelContent.Part.text($0) }
+      ),
       requestOptions: requestOptions,
       urlSession: .shared
     )

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -53,7 +53,13 @@ final class GoogleGenerativeAITests: XCTestCase {
     let _ = GenerativeModel(
       name: "gemini-1.5-pro-latest",
       apiKey: "API_KEY",
-      systemInstruction: "Talk like a pirate"
+      systemInstruction: "Talk like a pirate."
+    )
+
+    let _ = GenerativeModel(
+      name: "gemini-1.5-pro-latest",
+      apiKey: "API_KEY",
+      systemInstruction: "Talk like a pirate.", "Your name is Francis Drake."
     )
 
     // All arguments passed.


### PR DESCRIPTION
Updated the `GenerativeModel` constructor taking `systemInstruction: String` (from #152) to accept a variadic `String...`. The Gemini 1.5 model supports multiple text-only system instructions.