### PR TITLE
Re-order the `GenerativeModel` convenience constructors in source

### DIFF
--- a/Sources/GoogleAI/GenerativeModel.swift
+++ b/Sources/GoogleAI/GenerativeModel.swift
@@ -55,6 +55,41 @@ public final class GenerativeModel {
   ///   - safetySettings: A value describing what types of harmful content your model should allow.
   ///   - tools: A list of ``Tool`` objects  that the model may use to generate the next response.
   ///   - systemInstruction: Instructions that direct the model to behave a certain way; currently
+  ///     only text content is supported, e.g.,
+  ///     `ModelContent(role: "system", parts: "You are a cat. Your name is Neko.")`.
+  ///   - toolConfig: Tool configuration for any `Tool` specified in the request.
+  ///   - requestOptions Configuration parameters for sending requests to the backend.
+  public convenience init(name: String,
+                          apiKey: String,
+                          generationConfig: GenerationConfig? = nil,
+                          safetySettings: [SafetySetting]? = nil,
+                          tools: [Tool]? = nil,
+                          toolConfig: ToolConfig? = nil,
+                          systemInstruction: ModelContent? = nil,
+                          requestOptions: RequestOptions = RequestOptions()) {
+    self.init(
+      name: name,
+      apiKey: apiKey,
+      generationConfig: generationConfig,
+      safetySettings: safetySettings,
+      tools: tools,
+      toolConfig: toolConfig,
+      systemInstruction: systemInstruction,
+      requestOptions: requestOptions,
+      urlSession: .shared
+    )
+  }
+
+  /// Initializes a new remote model with the given parameters.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the model to use, e.g., `"gemini-1.5-pro-latest"`; see
+  ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
+  ///   - apiKey: The API key for your project.
+  ///   - generationConfig: The content generation parameters your model should use.
+  ///   - safetySettings: A value describing what types of harmful content your model should allow.
+  ///   - tools: A list of ``Tool`` objects  that the model may use to generate the next response.
+  ///   - systemInstruction: Instructions that direct the model to behave a certain way; currently
   ///     only text content is supported, e.g., "You are a cat. Your name is Neko."
   ///   - toolConfig: Tool configuration for any `Tool` specified in the request.
   ///   - requestOptions Configuration parameters for sending requests to the backend.
@@ -77,41 +112,6 @@ public final class GenerativeModel {
         role: "system",
         parts: systemInstruction.map { ModelContent.Part.text($0) }
       ),
-      requestOptions: requestOptions,
-      urlSession: .shared
-    )
-  }
-
-  /// Initializes a new remote model with the given parameters.
-  ///
-  /// - Parameters:
-  ///   - name: The name of the model to use, e.g., `"gemini-1.5-pro-latest"`; see
-  ///     [Gemini models](https://ai.google.dev/models/gemini) for a list of supported model names.
-  ///   - apiKey: The API key for your project.
-  ///   - generationConfig: The content generation parameters your model should use.
-  ///   - safetySettings: A value describing what types of harmful content your model should allow.
-  ///   - tools: A list of ``Tool`` objects  that the model may use to generate the next response.
-  ///   - systemInstruction: Instructions that direct the model to behave a certain way; currently
-  ///     only text content is supported, e.g.,
-  ///     `ModelContent(role: "system", parts: "You are a cat. Your name is Neko.")`.
-  ///   - toolConfig: Tool configuration for any `Tool` specified in the request.
-  ///   - requestOptions Configuration parameters for sending requests to the backend.
-  public convenience init(name: String,
-                          apiKey: String,
-                          generationConfig: GenerationConfig? = nil,
-                          safetySettings: [SafetySetting]? = nil,
-                          tools: [Tool]? = nil,
-                          toolConfig: ToolConfig? = nil,
-                          systemInstruction: ModelContent? = nil,
-                          requestOptions: RequestOptions = RequestOptions()) {
-    self.init(
-      name: name,
-      apiKey: apiKey,
-      generationConfig: generationConfig,
-      safetySettings: safetySettings,
-      tools: tools,
-      toolConfig: toolConfig,
-      systemInstruction: systemInstruction,
       requestOptions: requestOptions,
       urlSession: .shared
     )


### PR DESCRIPTION
Moved the `GenerativeModel` convenience constructor accepting a `systemInstruction: ModelContent? = nil` above the one accepting `systemInstruction: String...` in `GenerativeModel.swift`. Xcode's autocomplete seems to order them based on the order they appear in the source file. Previously the first constructor listed appeared to require `systemInstruction`, which might mislead devs into thinking it is required.

Before:
![Xcode Autocomplete Screenshot - Before](https://github.com/google-gemini/generative-ai-swift/assets/3010484/c575506d-14cd-42f4-a0c7-43c2d698bb27)

After:
![Xcode Autocomplete Screenshot - After](https://github.com/google-gemini/generative-ai-swift/assets/3010484/956a1f87-e29c-421b-929c-97ffd0de495d)

Note: This is not a breaking change, only cosmetic, `systemInstruction: nil` has always been supported since being introduced in the https://github.com/google-gemini/generative-ai-swift/releases/tag/0.4.11.