### PR TITLE
Add `ModelContent` tests for `fileData` parts

### DIFF
--- a/Sources/GoogleAI/ModelContent.swift
+++ b/Sources/GoogleAI/ModelContent.swift
@@ -35,6 +35,10 @@ public struct ModelContent: Equatable {
 
     /// URI-based data with a specified media type.
     ///
+    /// > Important: Files must be uploaded using the
+    /// > [`media.upload` REST API](https://ai.google.dev/api/rest/v1beta/media/upload) or another
+    /// > Gemini SDK.
+    ///
     /// > Note: Supported media types depends on the model; see
     /// > [supported file
     /// > formats](https://ai.google.dev/tutorials/prompting_with_media#supported_file_formats)

--- a/Tests/GoogleAITests/GoogleAITests.swift
+++ b/Tests/GoogleAITests/GoogleAITests.swift
@@ -90,6 +90,13 @@ final class GoogleGenerativeAITests: XCTestCase {
     let _ = try await genAI.generateContent(str)
     let _ = try await genAI.generateContent([str])
     let _ = try await genAI.generateContent(str, "abc", "def")
+    let _ = try await genAI.generateContent(
+      str,
+      ModelContent.Part.fileData(
+        mimetype: "image/jpeg",
+        uri: "https://generativelanguage.googleapis.com/v1beta/files/rand0mha5sh"
+      )
+    )
     #if canImport(UIKit)
       _ = try await genAI.generateContent(UIImage())
       _ = try await genAI.generateContent([UIImage()])

--- a/Tests/GoogleAITests/ModelContentTests.swift
+++ b/Tests/GoogleAITests/ModelContentTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import GoogleGenerativeAI
+import XCTest
+
+@available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
+final class ModelContentTests: XCTestCase {
+  let encoder = JSONEncoder()
+
+  override func setUp() {
+    encoder.outputFormatting = .init(
+      arrayLiteral: .prettyPrinted, .sortedKeys, .withoutEscapingSlashes
+    )
+  }
+
+  // MARK: ModelContent.Part Encoding
+
+  func testEncodeFileDataPart() throws {
+    let mimeType = "image/jpeg"
+    let fileURI = "gs://test-bucket/image.jpg"
+    let fileDataPart = ModelContent.Part.fileData(mimetype: mimeType, uri: fileURI)
+
+    let jsonData = try encoder.encode(fileDataPart)
+
+    let json = try XCTUnwrap(String(data: jsonData, encoding: .utf8))
+    XCTAssertEqual(json, """
+    {
+      "fileData" : {
+        "file_uri" : "\(fileURI)",
+        "mime_type" : "\(mimeType)"
+      }
+    }
+    """)
+  }
+}


### PR DESCRIPTION
- Added JSON encoding tests for `ModelContent.Part.fileData` and an API test. Ported from https://github.com/firebase/firebase-ios-sdk/pull/12886.
- Added a documentation link to the `media.upload` REST API referenced in https://github.com/google-gemini/generative-ai-swift/pull/134.