### PR TITLE
Make `text` computed property handle mixed-parts responses

### DIFF
--- a/Sources/GoogleAI/GenerateContentResponse.swift
+++ b/Sources/GoogleAI/GenerateContentResponse.swift
@@ -45,11 +45,17 @@ public struct GenerateContentResponse {
       Logging.default.error("Could not get text from a response that had no candidates.")
       return nil
     }
-    guard let text = candidate.content.parts.first?.text else {
+    let textValues: [String] = candidate.content.parts.compactMap { part in
+      guard case let .text(text) = part else {
+        return nil
+      }
+      return text
+    }
+    guard textValues.count > 0 else {
       Logging.default.error("Could not get a text part from the first candidate.")
       return nil
     }
-    return text
+    return textValues.joined()
   }
 
   /// Returns function calls found in any `Part`s of the first candidate of the response, if any.

--- a/Sources/GoogleAI/GenerateContentResponse.swift
+++ b/Sources/GoogleAI/GenerateContentResponse.swift
@@ -55,7 +55,7 @@ public struct GenerateContentResponse {
       Logging.default.error("Could not get a text part from the first candidate.")
       return nil
     }
-    return textValues.joined()
+    return textValues.joined(separator: " ")
   }
 
   /// Returns function calls found in any `Part`s of the first candidate of the response, if any.

--- a/Tests/GoogleAITests/GenerateContentResponses/unary-success-function-call-mixed-content.json
+++ b/Tests/GoogleAITests/GenerateContentResponses/unary-success-function-call-mixed-content.json
@@ -1,0 +1,37 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "The sum of [1, 2"
+          },
+          {
+            "functionCall": {
+              "name": "sum",
+              "args": {
+                "y": 1,
+                "x": 2
+              }
+            }
+          },
+          {
+            "text": ", 3] is "
+          },
+          {
+            "functionCall": {
+              "name": "sum",
+              "args": {
+                "y": 3,
+                "x": 3
+              }
+            }
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}

--- a/Tests/GoogleAITests/GenerateContentResponses/unary-success-function-call-mixed-content.json
+++ b/Tests/GoogleAITests/GenerateContentResponses/unary-success-function-call-mixed-content.json
@@ -4,7 +4,7 @@
       "content": {
         "parts": [
           {
-            "text": "The sum of [1, 2"
+            "text": "The sum of [1, 2,"
           },
           {
             "functionCall": {
@@ -16,7 +16,7 @@
             }
           },
           {
-            "text": ", 3] is "
+            "text": "3] is"
           },
           {
             "functionCall": {

--- a/Tests/GoogleAITests/GenerateContentResponses/unary-success-function-call-parallel-calls.json
+++ b/Tests/GoogleAITests/GenerateContentResponses/unary-success-function-call-parallel-calls.json
@@ -1,0 +1,40 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "sum",
+              "args": {
+                "y": 1,
+                "x": 2
+              }
+            }
+          },
+          {
+            "functionCall": {
+              "name": "sum",
+              "args": {
+                "y": 3,
+                "x": 4
+              }
+            }
+          },
+          {
+            "functionCall": {
+              "name": "sum",
+              "args": {
+                "y": 5,
+                "x": 6
+              }
+            }
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0
+    }
+  ]
+}

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -285,7 +285,7 @@ final class GenerativeModelTests: XCTestCase {
     let functionCalls = response.functionCalls
     XCTAssertEqual(functionCalls.count, 2)
     let text = try XCTUnwrap(response.text)
-    XCTAssertEqual(text, "The sum of [1, 2, 3] is ")
+    XCTAssertEqual(text, "The sum of [1, 2, 3] is")
   }
 
   func testGenerateContent_usageMetadata() async throws {

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -254,6 +254,40 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(response.functionCalls, [functionCall])
   }
 
+  func testGenerateContent_success_functionCall_parallelCalls() async throws {
+    MockURLProtocol
+      .requestHandler = try httpRequestHandler(
+        forResource: "unary-success-function-call-parallel-calls",
+        withExtension: "json"
+      )
+
+    let response = try await model.generateContent(testPrompt)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    XCTAssertEqual(candidate.content.parts.count, 3)
+    let functionCalls = response.functionCalls
+    XCTAssertEqual(functionCalls.count, 3)
+  }
+
+  func testGenerateContent_success_functionCall_mixedContent() async throws {
+    MockURLProtocol
+      .requestHandler = try httpRequestHandler(
+        forResource: "unary-success-function-call-mixed-content",
+        withExtension: "json"
+      )
+
+    let response = try await model.generateContent(testPrompt)
+
+    XCTAssertEqual(response.candidates.count, 1)
+    let candidate = try XCTUnwrap(response.candidates.first)
+    XCTAssertEqual(candidate.content.parts.count, 4)
+    let functionCalls = response.functionCalls
+    XCTAssertEqual(functionCalls.count, 2)
+    let text = try XCTUnwrap(response.text)
+    XCTAssertEqual(text, "The sum of [1, 2, 3] is ")
+  }
+
   func testGenerateContent_usageMetadata() async throws {
     MockURLProtocol
       .requestHandler = try httpRequestHandler(


### PR DESCRIPTION
- Added support for responses that include both `text` and `functionCall` parts (or other content types in the future).
  - Note: Multiple `text` parts in a single response is theoretical at this time (may need to revisit the joining approach if the output doesn't match our expectations).
- Also added a test for parallel function calling (multiple `functionCall` parts in one response).

See https://github.com/firebase/firebase-js-sdk/pull/8229 for JS (Vertex AI) equivalent.