### PR TITLE
Add default `RequestOptions.timeout` of 300 seconds

### DIFF
--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -36,10 +36,9 @@ public struct RequestOptions {
   /// Initializes a request options object.
   ///
   /// - Parameters:
-  ///   - timeout The request’s timeout interval in seconds; if not specified uses the default value
-  ///   for a `URLRequest`.
-  ///   - apiVersion The API version to use in requests to the backend; defaults to "v1beta".
-  public init(timeout: TimeInterval? = nil, apiVersion: String = "v1beta") {
+  ///   - timeout: The request’s timeout interval in seconds; defaults to 300 seconds (5 minutes).
+  ///   - apiVersion: The API version to use in requests to the backend; defaults to "v1beta".
+  public init(timeout: TimeInterval? = 300.0, apiVersion: String = "v1beta") {
     self.timeout = timeout
     self.apiVersion = apiVersion
   }

--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -26,9 +26,8 @@ protocol GenerativeAIRequest: Encodable {
 /// Configuration parameters for sending requests to the backend.
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public struct RequestOptions {
-  /// The request’s timeout interval in seconds; if not specified uses the default value for a
-  /// `URLRequest`.
-  let timeout: TimeInterval?
+  /// The request’s timeout interval in seconds.
+  let timeout: TimeInterval
 
   /// The API version to use in requests to the backend.
   let apiVersion: String
@@ -38,7 +37,7 @@ public struct RequestOptions {
   /// - Parameters:
   ///   - timeout: The request’s timeout interval in seconds; defaults to 300 seconds (5 minutes).
   ///   - apiVersion: The API version to use in requests to the backend; defaults to "v1beta".
-  public init(timeout: TimeInterval? = 300.0, apiVersion: String = "v1beta") {
+  public init(timeout: TimeInterval = 300.0, apiVersion: String = "v1beta") {
     self.timeout = timeout
     self.apiVersion = apiVersion
   }

--- a/Sources/GoogleAI/GenerativeAIService.swift
+++ b/Sources/GoogleAI/GenerativeAIService.swift
@@ -156,10 +156,7 @@ struct GenerativeAIService {
     let encoder = JSONEncoder()
     encoder.keyEncodingStrategy = .convertToSnakeCase
     urlRequest.httpBody = try encoder.encode(request)
-
-    if let timeoutInterval = request.options.timeout {
-      urlRequest.timeoutInterval = timeoutInterval
-    }
+    urlRequest.timeoutInterval = request.options.timeout
 
     return urlRequest
   }

--- a/Tests/GoogleAITests/GenerativeModelTests.swift
+++ b/Tests/GoogleAITests/GenerativeModelTests.swift
@@ -611,21 +611,14 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(response.candidates.count, 1)
   }
 
-  func testGenerateContent_requestOptions_nilTimeout() async throws {
-    let expectedTimeout: TimeInterval? = nil
+  func testGenerateContent_requestOptions_defaultTimeout() async throws {
+    let expectedTimeout = 300.0 // Default in timeout in RequestOptions()
     MockURLProtocol
       .requestHandler = try httpRequestHandler(
         forResource: "unary-success-basic-reply-short",
         withExtension: "json",
         timeout: expectedTimeout
       )
-    let requestOptions = RequestOptions(timeout: expectedTimeout)
-    model = GenerativeModel(
-      name: "my-model",
-      apiKey: "API_KEY",
-      requestOptions: requestOptions,
-      urlSession: urlSession
-    )
 
     let response = try await model.generateContent(testPrompt)
 
@@ -988,21 +981,14 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(responses, 1)
   }
 
-  func testGenerateContentStream_requestOptions_nilTimeout() async throws {
-    let expectedTimeout: TimeInterval? = nil
+  func testGenerateContentStream_requestOptions_defaultTimeout() async throws {
+    let expectedTimeout = 300.0 // Default in timeout in RequestOptions()
     MockURLProtocol
       .requestHandler = try httpRequestHandler(
         forResource: "streaming-success-basic-reply-short",
         withExtension: "txt",
         timeout: expectedTimeout
       )
-    let requestOptions = RequestOptions(timeout: expectedTimeout)
-    model = GenerativeModel(
-      name: "my-model",
-      apiKey: "API_KEY",
-      requestOptions: requestOptions,
-      urlSession: urlSession
-    )
 
     var responses = 0
     let stream = model.generateContentStream(testPrompt)
@@ -1066,21 +1052,14 @@ final class GenerativeModelTests: XCTestCase {
     XCTAssertEqual(response.totalTokens, 6)
   }
 
-  func testCountTokens_requestOptions_nilTimeout() async throws {
-    let expectedTimeout: TimeInterval? = nil
+  func testCountTokens_requestOptions_defaultTimeout() async throws {
+    let expectedTimeout = 300.0
     MockURLProtocol
       .requestHandler = try httpRequestHandler(
         forResource: "success-total-tokens",
         withExtension: "json",
         timeout: expectedTimeout
       )
-    let requestOptions = RequestOptions(timeout: expectedTimeout)
-    model = GenerativeModel(
-      name: "my-model",
-      apiKey: "API_KEY",
-      requestOptions: requestOptions,
-      urlSession: urlSession
-    )
 
     let response = try await model.countTokens(testPrompt)
 
@@ -1135,7 +1114,7 @@ final class GenerativeModelTests: XCTestCase {
   private func httpRequestHandler(forResource name: String,
                                   withExtension ext: String,
                                   statusCode: Int = 200,
-                                  timeout: TimeInterval? = RequestOptions()
+                                  timeout: TimeInterval = RequestOptions()
                                     .timeout) throws -> ((URLRequest) throws -> (
     URLResponse,
     AsyncLineSequence<URL.AsyncBytes>?
@@ -1144,11 +1123,7 @@ final class GenerativeModelTests: XCTestCase {
     return { request in
       let requestURL = try XCTUnwrap(request.url)
       XCTAssertEqual(requestURL.path.occurrenceCount(of: "models/"), 1)
-      if let timeout {
-        XCTAssertEqual(request.timeoutInterval, timeout)
-      } else {
-        XCTAssertEqual(request.timeoutInterval, URLRequest.defaultTimeoutInterval())
-      }
+      XCTAssertEqual(request.timeoutInterval, timeout)
       let response = try XCTUnwrap(HTTPURLResponse(
         url: requestURL,
         statusCode: statusCode,


### PR DESCRIPTION
Updated the default request timeout to 300 seconds (5 minutes) instead of using the [platform default](https://developer.apple.com/documentation/foundation/nsurlsessionconfiguration/1408259-timeoutintervalforrequest#discussion) (currently 60 seconds).