### PR TITLE
Update models in samples and README to `gemini-1.5-flash-latest`

### DIFF
--- a/Examples/GenerativeAICLI/Sources/GenerateContent.swift
+++ b/Examples/GenerativeAICLI/Sources/GenerateContent.swift
@@ -55,23 +55,7 @@ struct GenerateContent: AsyncParsableCommand {
 
   mutating func run() async throws {
     do {
-      let safetySettings = [SafetySetting(harmCategory: .dangerousContent, threshold: .blockNone)]
-      // Let the server pick the default config.
-      let config = GenerationConfig(
-        temperature: 0.2,
-        topP: 0.1,
-        topK: 16,
-        candidateCount: 1,
-        maxOutputTokens: isStreaming ? nil : 256,
-        stopSequences: nil
-      )
-
-      let model = GenerativeModel(
-        name: modelNameOrDefault(),
-        apiKey: apiKey,
-        generationConfig: config,
-        safetySettings: safetySettings
-      )
+      let model = GenerativeModel(name: modelNameOrDefault(), apiKey: apiKey)
 
       var parts = [ModelContent.Part]()
 
@@ -115,12 +99,10 @@ struct GenerateContent: AsyncParsableCommand {
   }
 
   func modelNameOrDefault() -> String {
-    if let modelName = modelName {
+    if let modelName {
       return modelName
-    } else if imageURL != nil {
-      return "gemini-1.0-pro-vision-latest"
     } else {
-      return "gemini-1.0-pro"
+      return "gemini-1.5-flash-latest"
     }
   }
 }

--- a/Examples/GenerativeAISample/ChatSample/ViewModels/ConversationViewModel.swift
+++ b/Examples/GenerativeAISample/ChatSample/ViewModels/ConversationViewModel.swift
@@ -36,7 +36,7 @@ class ConversationViewModel: ObservableObject {
   private var chatTask: Task<Void, Never>?
 
   init() {
-    model = GenerativeModel(name: "gemini-1.0-pro", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
     chat = model.startChat()
   }
 

--- a/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
+++ b/Examples/GenerativeAISample/FunctionCallingSample/ViewModels/FunctionCallingViewModel.swift
@@ -39,7 +39,7 @@ class FunctionCallingViewModel: ObservableObject {
 
   init() {
     model = GenerativeModel(
-      name: "gemini-1.0-pro",
+      name: "gemini-1.5-flash-latest",
       apiKey: APIKey.default,
       tools: [Tool(functionDeclarations: [
         FunctionDeclaration(

--- a/Examples/GenerativeAISample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
+++ b/Examples/GenerativeAISample/GenerativeAIMultimodalSample/ViewModels/PhotoReasoningViewModel.swift
@@ -44,7 +44,7 @@ class PhotoReasoningViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = GenerativeModel(name: "gemini-1.0-pro-vision-latest", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
   }
 
   func reason() async {

--- a/Examples/GenerativeAISample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
+++ b/Examples/GenerativeAISample/GenerativeAITextSample/ViewModels/SummarizeViewModel.swift
@@ -32,7 +32,7 @@ class SummarizeViewModel: ObservableObject {
   private var model: GenerativeModel?
 
   init() {
-    model = GenerativeModel(name: "gemini-1.0-pro", apiKey: APIKey.default)
+    model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: APIKey.default)
   }
 
   func summarize(inputText: String) async {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example, with just a few lines of code, you can access Gemini's multimodal c
 generate text from text-and-image input:
 
 ```swift
-let model = GenerativeModel(name: "gemini-1.5-pro-latest", apiKey: "YOUR_API_KEY")
+let model = GenerativeModel(name: "gemini-1.5-flash-latest", apiKey: "YOUR_API_KEY")
 let cookieImage = UIImage(...)
 let prompt = "Do these look store-bought or homemade?"
 


### PR DESCRIPTION
- Updated the samples and documentation to use the `gemini-1.5-flash-latest` model name.
- Removed hardcoded [SafetySetting] and `GenerationConfig` in the CLI tool.
  - This lets the server pick the default values.
- CLI tool no longer needs to check for image parts since `gemini-1.5-flash-latest` supports both text-only and multimodal prompts.