### PR TITLE
Add `responseSchema` to `GenerationConfig`

### DIFF
--- a/Sources/GoogleAI/GenerationConfig.swift
+++ b/Sources/GoogleAI/GenerationConfig.swift
@@ -70,6 +70,12 @@ public struct GenerationConfig {
   /// - `application/json`: JSON response in the candidates.
   public let responseMIMEType: String?
 
+  /// Output response schema of the generated candidate text.
+  ///
+  /// - Note: This only applies when the specified ``responseMIMEType`` supports a schema; currently
+  ///   this is limited to `application/json`.
+  public let responseSchema: Schema?
+
   /// Creates a new `GenerationConfig` value.
   ///
   /// - Parameters:
@@ -80,9 +86,11 @@ public struct GenerationConfig {
   ///   - maxOutputTokens: See ``maxOutputTokens``.
   ///   - stopSequences: See ``stopSequences``.
   ///   - responseMIMEType: See ``responseMIMEType``.
+  ///   - responseSchema: See ``responseSchema``.
   public init(temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil,
               candidateCount: Int? = nil, maxOutputTokens: Int? = nil,
-              stopSequences: [String]? = nil, responseMIMEType: String? = nil) {
+              stopSequences: [String]? = nil, responseMIMEType: String? = nil,
+              responseSchema: Schema? = nil) {
     // Explicit init because otherwise if we re-arrange the above variables it changes the API
     // surface.
     self.temperature = temperature
@@ -92,6 +100,7 @@ public struct GenerationConfig {
     self.maxOutputTokens = maxOutputTokens
     self.stopSequences = stopSequences
     self.responseMIMEType = responseMIMEType
+    self.responseSchema = responseSchema
   }
 }
 


### PR DESCRIPTION
This extends the JSON generation supported added in https://github.com/google-gemini/generative-ai-swift/pull/161 (for `responseMIMEType: "application/json"`) with a schema for strictly defining the JSON output's structure.

Note: Currently only supported on the `gemini-1.5-pro-latest` model.

TODOs:
- Clean-up manual testing in the CLI tool.
- Add unit tests for GenerationConfig showing the schema being serialized.