### PR TITLE
Log server error responses without `-GoogleGenerativeAIDebugLogEnabled`

### DIFF
--- a/Sources/GoogleAI/GenerativeAIService.swift
+++ b/Sources/GoogleAI/GenerativeAIService.swift
@@ -41,9 +41,9 @@ struct GenerativeAIService {
 
     // Verify the status code is 200
     guard response.statusCode == 200 else {
-      Logging.default.error("[GoogleGenerativeAI] The server responded with an error: \(response)")
+      Logging.network.error("[GoogleGenerativeAI] The server responded with an error: \(response)")
       if let responseString = String(data: data, encoding: .utf8) {
-        Logging.network.error("[GoogleGenerativeAI] Response payload: \(responseString)")
+        Logging.default.error("[GoogleGenerativeAI] Response payload: \(responseString)")
       }
 
       throw parseError(responseData: data)
@@ -89,14 +89,14 @@ struct GenerativeAIService {
 
         // Verify the status code is 200
         guard response.statusCode == 200 else {
-          Logging.default
+          Logging.network
             .error("[GoogleGenerativeAI] The server responded with an error: \(response)")
           var responseBody = ""
           for try await line in stream.lines {
             responseBody += line + "\n"
           }
 
-          Logging.network.error("[GoogleGenerativeAI] Response payload: \(responseBody)")
+          Logging.default.error("[GoogleGenerativeAI] Response payload: \(responseBody)")
           continuation.finish(throwing: parseError(responseBody: responseBody))
 
           return


### PR DESCRIPTION
Updated logging to print response payloads even when `-GoogleGenerativeAIDebugLogEnabled` is _not_ enabled. This is a port of https://github.com/firebase/firebase-ios-sdk/pull/13009.

<details>
<summary>Example Error Response Log</summary>

If a `responseMIMEType` of `application/json` (JSON mode) is specified for a model that doesn't support it (e.g., `gemini-1.0-pro`):

```
[GoogleGenerativeAI] Response payload: {
  "error": {
    "code": 400,
    "message": "Json mode is not enabled for models/gemini-1.0-pro",
    "status": "INVALID_ARGUMENT"
  }
}
```

</details>

Updated logging to only print the `NSHTTPURLResponse` if `-GoogleGenerativeAIDebugLogEnabled` is enabled.

<details>
<summary>Example NSHTTPURLResponse Log</summary>

```
[GoogleGenerativeAI] The server responded with an error: <NSHTTPURLResponse: 0x600002abc760> { URL: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.0-pro:generateContent } { Status Code: 400, Headers {
    "Alt-Svc" =     (
        "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
    );
    "Cache-Control" =     (
        private
    );
    "Content-Encoding" =     (
        gzip
    );
    "Content-Length" =     (
        138
    );
    "Content-Type" =     (
        "application/json; charset=UTF-8"
    );
    Date =     (
        "Wed, 29 May 2024 14:35:12 GMT"
    );
    Server =     (
        "scaffolding on HTTPServer2"
    );
    Vary =     (
        Origin,
        "X-Origin",
        Referer
    );
    "server-timing" =     (
        "gfet4t7; dur=250"
    );
    "x-content-type-options" =     (
        nosniff
    );
    "x-frame-options" =     (
        SAMEORIGIN
    );
    "x-xss-protection" =     (
        0
    );
} }
```

</details>

These were swapped because the `NSHTTPURLResponse` is rarely useful for understanding an error on its own, whereas the response payload contains details to fix the problem.