### PR TITLE
Update Xcode version in CLI workflow

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,7 +18,7 @@ jobs:
         os: [macos-13]
         include:
           - os: macos-13
-            xcode: Xcode_15.0.1
+            xcode: Xcode_15.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,7 +18,7 @@ jobs:
         os: [macos-13]
         include:
           - os: macos-13
-            xcode: Xcode_15.0.1
+            xcode: Xcode_15.2
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,7 +18,7 @@ jobs:
         os: [macos-13]
         include:
           - os: macos-13
-            xcode: Xcode_15.2
+            xcode: Xcode_15.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,7 +18,7 @@ jobs:
         os: [macos-13]
         include:
           - os: macos-13
-            xcode: Xcode_15.1
+            xcode: Xcode_15.0.1
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The start of the CLI workflow [failures](https://github.com/google-gemini/generative-ai-swift/actions/runs/10004031795) seems to coincide with the https://github.com/apple/swift-argument-parser/releases/tag/1.5.0. Bumping the workflow from Xcode 15.0.1 to 15.1 resolves the error.