### PR TITLE
Add a README for /samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -10,7 +10,7 @@ Each file is structured as a runnable test case, ensuring that samples are execu
 
 | File | Description |
 | ---- | ----------- |
-| [APIKey.swift](./APIKey.swift) | Seetting up your API key |
+| [APIKey.swift](./APIKey.swift) | Setting up your API key |
 | [ChatSnippets.swift](./ChatSnippets.swift) | Multi-turn chat conversations |
 | [CodeExecution.swift](./CodeExecution.swift) | Executing code |
 | [ControlledGeneration.swift](./ControlledGeneration.swift) | Generating content with output constraints (e.g. JSON mode) |

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,22 @@
+# Gemini API Swift SDK sample code
+
+This directory contains sample code for key features of the SDK, organised by high level feature.
+
+These samples are embedded in parts of the [documentation](https://ai.google.dev), most notably in the [API reference](https://ai.google.dev/api).
+
+Each file is structured as a runnable test case, ensuring that samples are executable and functional. Each test demonstrates a single concept, and contains region tags that are used to demarcate the test scaffolding from the spotlight code. If you are contributing, code within region tags should follow sample code best practices - being clear, complete and concise.
+
+## Contents
+
+| File | Description |
+| ---- | ----------- |
+| [APIKey.swift](./APIKey.swift) | Seetting up your API key |
+| [ChatSnippets.swift](./ChatSnippets.swift) | Multi-turn chat conversations |
+| [CodeExecution.swift](./CodeExecution.swift) | Executing code |
+| [ControlledGeneration.swift](./ControlledGeneration.swift) | Generating content with output constraints (e.g. JSON mode) |
+| [CountTokens.swift](./CountTokens.swift) | Counting input and output tokens |
+| [FunctionCalling.swift](./FunctionCalling.swift) | Using function calling |
+| [GenerationConfig.swift](./GenerationConfig.swift) | Setting model parameters |
+| [SafetySettings.swift](./SafetySettings.swift) | Setting and using safety controls |
+| [SystemInstructions.swift](./SystemInstructions.swift) | Setting system instructions |
+| [TextGeneration.swift](./TextGeneration.swift) | Generating text |


### PR DESCRIPTION
I'm making sure all samples in our various repos have a ToC. This matches the Python & REST READMEs, and I can add a GitHub action if you like - just LMK.

 * [Python and REST](https://github.com/google-gemini/generative-ai-python/commit/db311dd3f26233206a65b946a17417837ae12905)
 * [GitHub action](https://github.com/google-gemini/generative-ai-python/blob/main/.github/workflows/samples.yaml)
