### PR TITLE
Update `palm` branch README for PaLM API decommissioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 > [!CAUTION]
 > This version (`0.3.0`) of the SDK was intended for use with the PaLM API,
-> which is now [decommissioned](https://ai.google.dev/palm_docs/deprecation) as
-> August 20, 2024. This means that users cannot use a PaLM model in a prompt,
-> tune a new PaLM model, or run inference on PaLM-tuned models.
+> which is now [decommissioned](https://ai.google.dev/palm_docs/deprecation).
+> This means that users cannot use a PaLM model in a prompt, tune a new PaLM
+> model, or run inference on PaLM-tuned models.
+>
+> Note: This is different from the
+> [Vertex AI PaLM API](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text),
+> which is scheduled to be decommissioned in October 2024.
 
 To interact with models using Google AI services and tooling, use the Gemini
 API, which is now available in a stable version. For more information on

--- a/README.md
+++ b/README.md
@@ -1,90 +1,17 @@
-# Google AI Swift SDK for PaLM
+# Google AI Swift SDK for PaLM (Decommissioned)
 
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgoogle%2Fgenerative-ai-swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/google/generative-ai-swift)
-[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgoogle%2Fgenerative-ai-swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/google/generative-ai-swift)
+> [!CAUTION]
+> This version (`0.3.0`) of the SDK was intended for use with the PaLM API,
+> which is now [decommissioned](https://ai.google.dev/palm_docs/deprecation) as
+> August 20, 2024. This means that users cannot use a PaLM model in a prompt,
+> tune a new PaLM model, or run inference on PaLM-tuned models.
 
-> [!IMPORTANT]
-> This version (`0.3.0`) of the SDK is intended for being used with the PaLM LLM. If you would like to use the Gemini multimodal model, please migrate to the `main` branch to use the new version of the SDK.
-
-The Google Generative AI SDK for Swift allows developers to use state-of-the-art Large Language Models (LLMs) to build language applications.
-
-Once you've added the Swift package to your Swift application, you can call the API as follows:
-
-```swift
-import GoogleGenerativeAI
-
-let palmClient = GenerativeLanguage(apiKey: "YOUR API KEY")
-response = try await palmClient.chat(message: "Hello")
-```
-
-
-## Getting Started
-
-This repository contains a few sample apps. To try them out, follow these steps:
-
-1. Check out this repository.
-    ```swift
-    git clone https://github.com/google/generative-ai-swift
-    ```
-1. Follow the instructions on the [setup page](https://developers.generativeai.google/tutorials/setup) to obtain an API key.
-1. Open and build one of the examples in the `Examples` folder.
-1. Paste the API key into the `API_KEY` property in the `PaLM-Info.plist` file.
-1. Run the app.
-
-
-## Using the PaLM SDK in your own app
-
-To use the Swift SDK for the PaLM API in your own apps, follow these steps:
-
-1. Create a new Swift app (or use your existing app).
-1. Right-click on your project in the project navigator.
-1. Select _Add Packages_ from the context menu.
-1. In the _Add Packages_ dialog, paste the package URL into the search bar: https://github.com/google/generative-ai-swift
-1. Click on _Add Package_. Xcode will now add the _GoogleGenerativeAI_ to your project.
-
-### Initializing the API client
-
-Before you can make any API calls, you need to import and initialize the API
-client.
-
-1.  Import the `GoogleGenerativeAI` module:
-    ```swift
-    import GoogleGenerativeAI
-    ```
-1.  Initialize the API client:
-    ```swift
-    let palmClient = GenerativeLanguage(apiKey: "YOUR API KEY")
-    ```
-
-### Calling the API
-
-Now you're ready to call the PaLM API's methods. 
-
-> **Note**: All API methods are asynchronous, so you need to call them using Swift's
-async/await.
-
-For example, here is how you can call the `generateText` method to summarize a Wikipedia article:
-
-```swift
-let prompt = "Summarise the following text: https://wikipedia.org/..."
-
-let response = try await palmClient.generateText(with: prompt)
-
-if let candidate = response?.candidates?.first, let text = candidate.output {
-  print(text)
-}
-```
-
-
-## Documentation
-
-You can find the documentation for the PaLM API at https://developers.generativeai.google.com/guide
-
-
-## Contributing
-
-See [Contributing](docs/CONTRIBUTING.md) for more information on contributing to the Generative AI SDK for Swift.
-
+To interact with models using Google AI services and tooling, use the Gemini
+API, which is now available in a stable version. For more information on
+migrating from PaLM to Gemini, see the
+[migration guide](https://ai.google.dev/docs/migration_guide) and the
+[`main`](https://github.com/google-gemini/generative-ai-swift/tree/main) branch
+of this repo to use the new version of the SDK.
 
 ## License
 


### PR DESCRIPTION
Updated the README in the `palm` branch to reflect that the PaLM SDK is now decommissioned (as of August 20, 2024) rather than deprecated.
