### PR TITLE
Update version to 0.5.6

### DIFF
--- a/Sources/GoogleAI/GenerativeAISwift.swift
+++ b/Sources/GoogleAI/GenerativeAISwift.swift
@@ -21,7 +21,7 @@ import Foundation
 @available(iOS 15.0, macOS 11.0, macCatalyst 15.0, *)
 public enum GenerativeAISwift {
   /// String value of the SDK version
-  public static let version = "0.5.4"
+  public static let version = "0.5.6"
   /// The Google AI backend endpoint URL.
   static let baseURL = "https://generativelanguage.googleapis.com"
 }


### PR DESCRIPTION
## Description of the change
Update version property to 0.5.6 in preparation of next release

## Motivation
Released version 0.5.5 does not match current source version 0.5.4. As a result, SDK requests contain the incorrect version.
`curl -H 'x-goog-api-key: AIz' -H 'Content-Type: application/json' -H 'x-goog-api-client: genai-swift/0.5.4'`

## Type of change
Bug fix

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [X] I have performed a self-review of my code.
- [X] I have added detailed comments to my code where applicable.
- [X] I have verified that my change does not break existing code.
- [X] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [X] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [X] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
