### PR TITLE
add `baseURL` for the proxy

### DIFF
--- a/Sources/GoogleAI/CountTokensRequest.swift
+++ b/Sources/GoogleAI/CountTokensRequest.swift
@@ -26,7 +26,7 @@ extension CountTokensRequest: GenerativeAIRequest {
   typealias Response = CountTokensResponse
 
   var url: URL {
-    URL(string: "\(GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model):countTokens")!
+    URL(string: "\(options.baseURL ?? GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model):countTokens")!
   }
 }
 

--- a/Sources/GoogleAI/GenerateContentRequest.swift
+++ b/Sources/GoogleAI/GenerateContentRequest.swift
@@ -46,7 +46,7 @@ extension GenerateContentRequest: GenerativeAIRequest {
   typealias Response = GenerateContentResponse
 
   var url: URL {
-    let modelURL = "\(GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model)"
+    let modelURL = "\(options.baseURL ?? GenerativeAISwift.baseURL)/\(options.apiVersion)/\(model)"
     if isStreaming {
       return URL(string: "\(modelURL):streamGenerateContent?alt=sse")!
     } else {

--- a/Sources/GoogleAI/GenerativeAIRequest.swift
+++ b/Sources/GoogleAI/GenerativeAIRequest.swift
@@ -31,14 +31,19 @@ public struct RequestOptions {
 
   /// The API version to use in requests to the backend.
   let apiVersion: String
+  
+  /// The Base URL for the proxy.
+  let baseURL: String?
 
   /// Initializes a request options object.
   ///
   /// - Parameters:
   ///   - timeout: The request’s timeout interval in seconds; defaults to 300 seconds (5 minutes).
   ///   - apiVersion: The API version to use in requests to the backend; defaults to "v1beta".
-  public init(timeout: TimeInterval = 300.0, apiVersion: String = "v1beta") {
+  ///   - baseURL: The Base URL for the proxy.
+  public init(timeout: TimeInterval = 300.0, apiVersion: String = "v1beta", baseURL: String? = nil) {
     self.timeout = timeout
     self.apiVersion = apiVersion
+    self.baseURL = baseURL
   }
 }


### PR DESCRIPTION
## Description of the change
Modified the url computed property within the GenerativeAIRequest extension to use the provided baseURL if available. If baseURL is nil, it defaults to GenerativeAISwift.baseURL.

## Motivation
The primary motivation for this change is to enable routing of requests through a custom server proxy. By introducing an optional baseURL, the application gains the ability to direct API calls through an intermediary server.

## Type of change
Feature request

## Checklist
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->
- [x] I have performed a self-review of my code.
- [x ] I have added detailed comments to my code where applicable.
- [x] I have verified that my change does not break existing code.
- [x] My PR is based on the latest changes of the main branch (if unsure, please run `git pull --rebase upstream main`).
- [x] I am familiar with the [Google Style Guide](https://google.github.io/styleguide/) for the language I have coded in.
- [x] I have read through the [Contributing Guide](https://github.com/google/generative-ai-swift/blob/main/docs/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://cla.developers.google.com/about).
